### PR TITLE
Error when multiple embeddedetcd's are changing wal.SegmentSizeBytes

### DIFF
--- a/config.go
+++ b/config.go
@@ -24,11 +24,13 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
 	"math/big"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync"
 	"time"
 
 	"go.etcd.io/etcd/client/pkg/v3/fileutil"
@@ -43,9 +45,27 @@ type Config struct {
 	*embed.Config
 }
 
+var (
+	walSegmentLock sync.Mutex
+	walSegmentSet  bool
+)
+
+func setWalSegmentSize(size int64) error {
+	walSegmentLock.Lock()
+	defer walSegmentLock.Unlock()
+	if walSegmentSet {
+		return fmt.Errorf("wal segment size already set to %d, cannot set to %d", wal.SegmentSizeBytes, size)
+	}
+	wal.SegmentSizeBytes = size
+	walSegmentSet = true
+	return nil
+}
+
 func NewConfig(o options.CompletedOptions, enableWatchCache bool) (*Config, error) {
 	if o.WalSizeBytes != 0 {
-		wal.SegmentSizeBytes = o.WalSizeBytes
+		if err := setWalSegmentSize(o.WalSizeBytes); err != nil {
+			return nil, err
+		}
 	}
 
 	cfg := embed.NewConfig()
@@ -107,7 +127,9 @@ func NewConfig(o options.CompletedOptions, enableWatchCache bool) (*Config, erro
 		cfg.MaxWalFiles = 1
 		cfg.MaxSnapFiles = 1
 		if o.WalSizeBytes == 0 {
-			wal.SegmentSizeBytes = 1 << 20 // 1MB instead of default 64MB
+			if err := setWalSegmentSize(1 << 20); err != nil { // 1MB instead of default 64MB
+				return nil, err
+			}
 		}
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -29,21 +29,21 @@ func TestUnsafeE2EHackDisableEtcdFsync(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	tests := []struct {
-		name                    string
-		envValue                string
-		walSizeBytesOption      int64
-		expectUnsafeNoFsync     bool
-		expectMaxWalFiles       uint
-		expectMaxSnapFiles      uint
-		expectWalSegmentSize    int64
+		name                 string
+		envValue             string
+		walSizeBytesOption   int64
+		expectUnsafeNoFsync  bool
+		expectMaxWalFiles    uint
+		expectMaxSnapFiles   uint
+		expectWalSegmentSize int64
 	}{
 		{
 			name:                 "env var not set",
 			envValue:             "",
 			walSizeBytesOption:   0,
 			expectUnsafeNoFsync:  false,
-			expectMaxWalFiles:    5, // etcd default
-			expectMaxSnapFiles:   5, // etcd default
+			expectMaxWalFiles:    5,                // etcd default
+			expectMaxSnapFiles:   5,                // etcd default
 			expectWalSegmentSize: 64 * 1024 * 1024, // 64MB default
 		},
 		{
@@ -116,5 +116,25 @@ func TestUnsafeE2EHackDisableEtcdFsync(t *testing.T) {
 				t.Errorf("wal.SegmentSizeBytes: got %v, want %v", wal.SegmentSizeBytes, tt.expectWalSegmentSize)
 			}
 		})
+	}
+}
+
+func TestNewConfigRejectsSecondWalSegmentSize(t *testing.T) {
+	dir1 := t.TempDir()
+	opts1 := options.NewOptions(dir1)
+	opts1.WalSizeBytes = 1 << 20
+	_, err := NewConfig(opts1.Complete(nil), false)
+	if err != nil {
+		// The first one failing doesn't matter. It's just to ensure
+		// that wal.SegmentSizeBytes was set once.
+		t.Logf("first NewConfig failed: %v", err)
+	}
+
+	dir2 := t.TempDir()
+	opts2 := options.NewOptions(dir2)
+	opts2.WalSizeBytes = 2 << 20
+	_, err = NewConfig(opts2.Complete(nil), false)
+	if err == nil {
+		t.Fatal("expected error from second NewConfig with different WalSizeBytes")
 	}
 }


### PR DESCRIPTION
This currently produces a race in kcp's CI.