### PR TITLE
allow specifying curve and change default to P-384

### DIFF
--- a/config.go
+++ b/config.go
@@ -66,7 +66,7 @@ func NewConfig(o options.CompletedOptions, enableWatchCache bool) (*Config, erro
 		return nil, err
 	}
 
-	if err := generateClientAndServerCerts([]string{"localhost"}, filepath.Join(cfg.Dir, "secrets")); err != nil {
+	if err := generateClientAndServerCerts([]string{"localhost"}, filepath.Join(cfg.Dir, "secrets"), o.ECDSACurve.Curve); err != nil {
 		return nil, err
 	}
 	cfg.PeerTLSInfo.ServerName = "localhost"
@@ -130,7 +130,8 @@ func (c *Config) Complete() CompletedConfig {
 	}}
 }
 
-func generateClientAndServerCerts(hosts []string, dir string) error {
+func generateClientAndServerCerts(hosts []string, dir string, curve elliptic.Curve) error {
+
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
@@ -183,17 +184,17 @@ func generateClientAndServerCerts(hosts []string, dir string) error {
 		BasicConstraintsValid: true,
 	}
 
-	caKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	caKey, err := ecdsa.GenerateKey(curve, rand.Reader)
 	if err != nil {
 		return err
 	}
 
-	serverKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	serverKey, err := ecdsa.GenerateKey(curve, rand.Reader)
 	if err != nil {
 		return err
 	}
 
-	clientKey, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	clientKey, err := ecdsa.GenerateKey(curve, rand.Reader)
 	if err != nil {
 		return err
 	}
@@ -245,3 +246,4 @@ func ecPrivateKeyToFile(key *ecdsa.PrivateKey, path string) error {
 	}
 	return os.WriteFile(path, buf.Bytes(), 0600)
 }
+

--- a/options/curve.go
+++ b/options/curve.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2026 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"crypto/elliptic"
+	"fmt"
+
+	"github.com/spf13/pflag"
+)
+
+// ECDSACurve wraps an elliptic.Curve and implements pflag.Value for flag parsing.
+type ECDSACurve struct {
+	elliptic.Curve
+}
+
+var _ pflag.Value = (*ECDSACurve)(nil)
+
+func (c *ECDSACurve) String() string {
+	if c.Curve == nil {
+		return ""
+	}
+	return c.Curve.Params().Name
+}
+
+func (c *ECDSACurve) Set(value string) error {
+	switch value {
+	case "P-224":
+		c.Curve = elliptic.P224()
+	case "P-256":
+		c.Curve = elliptic.P256()
+	case "P-384":
+		c.Curve = elliptic.P384()
+	case "P-521":
+		c.Curve = elliptic.P521()
+	default:
+		return fmt.Errorf("must be one of: P-224, P-256, P-384, P-521")
+	}
+	return nil
+}
+
+func (c *ECDSACurve) Type() string {
+	return "ECDSACurve"
+}

--- a/options/embedded.go
+++ b/options/embedded.go
@@ -17,6 +17,7 @@ limitations under the License.
 package options
 
 import (
+	"crypto/elliptic"
 	"fmt"
 	"path/filepath"
 
@@ -36,6 +37,7 @@ type Options struct {
 	WalSizeBytes      int64
 	QuotaBackendBytes int64
 	ForceNewCluster   bool
+	ECDSACurve        ECDSACurve
 }
 
 func NewOptions(rootDir string) *Options {
@@ -43,6 +45,7 @@ func NewOptions(rootDir string) *Options {
 		Directory:  filepath.Join(rootDir, "etcd-server"),
 		PeerPort:   "2380",
 		ClientPort: "2379",
+		ECDSACurve: ECDSACurve{Curve: elliptic.P384()},
 	}
 }
 
@@ -54,6 +57,7 @@ func (e *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.Int64Var(&e.WalSizeBytes, "embedded-etcd-wal-size-bytes", e.WalSizeBytes, "Size of embedded etcd WAL")
 	fs.Int64Var(&e.QuotaBackendBytes, "embedded-etcd-quota-backend-bytes", e.WalSizeBytes, "Alarm threshold for embedded etcd backend bytes")
 	fs.BoolVar(&e.ForceNewCluster, "embedded-etcd-force-new-cluster", e.ForceNewCluster, "Starts a new cluster from existing data restored from a different system")
+	fs.Var(&e.ECDSACurve, "embedded-etcd-ecdsa-curve", "ECDSA curve for TLS key generation. Supported values: P-224, P-256, P-384, P-521")
 }
 
 type completedOptions struct {


### PR DESCRIPTION
On a high level this changes two things:
* it allows for passing in `--embedded-etcd-ecdsa-curve` to specify the curve
* it changes the default curve from P-521 to P-384 (see discussion from community notes [Nov 20 2025](https://docs.google.com/document/d/1PrEhbmq1WfxFv1fTikDBZzXEIJkUWVHdqDFxaY1Ply4/edit?tab=t.0#heading=h.r2v7enakhpw2))

Implementation notes:
* with our pflag setup, a custom pflag type keeps the code most concise and all the parsing/evaluation in a single place
* `P-<prime>` is the canonical name Go uses on Curve.Params().Name, so I have chosen this for the flag value. WDYT, we can also go to `P<prime>` if we want to, but then we need another switch statement in .String(). Maybe I am just overthinking this 😅 